### PR TITLE
Minor refactor

### DIFF
--- a/appender.go
+++ b/appender.go
@@ -18,12 +18,10 @@ import (
 
 func TestAppender(t *testing.T, store types.Storager) {
 	Convey("Given a basic Storager", t, func() {
-		_, ok := store.(types.Appender)
+		ap, ok := store.(types.Appender)
 		So(ok, ShouldBeTrue)
 
 		Convey("When CreateAppend", func() {
-			ap, _ := store.(types.Appender)
-
 			path := uuid.NewString()
 			o, err := ap.CreateAppend(path)
 
@@ -45,8 +43,6 @@ func TestAppender(t *testing.T, store types.Storager) {
 		})
 
 		Convey("When Delete", func() {
-			ap, _ := store.(types.Appender)
-
 			path := uuid.NewString()
 			_, err := ap.CreateAppend(path)
 			if err != nil {
@@ -65,8 +61,6 @@ func TestAppender(t *testing.T, store types.Storager) {
 		})
 
 		Convey("When WriteAppend", func() {
-			ap, _ := store.(types.Appender)
-
 			path := uuid.NewString()
 			o, err := ap.CreateAppend(path)
 			if err != nil {
@@ -95,8 +89,6 @@ func TestAppender(t *testing.T, store types.Storager) {
 		})
 
 		Convey("When CommitAppend", func() {
-			ap, _ := store.(types.Appender)
-
 			path := uuid.NewString()
 			o, err := ap.CreateAppend(path)
 			if err != nil {

--- a/appender.go
+++ b/appender.go
@@ -18,10 +18,8 @@ import (
 
 func TestAppender(t *testing.T, store types.Storager) {
 	Convey("Given a basic Storager", t, func() {
-		Convey("The Storager should implement Appender", func() {
-			_, ok := store.(types.Appender)
-			So(ok, ShouldBeTrue)
-		})
+		_, ok := store.(types.Appender)
+		So(ok, ShouldBeTrue)
 
 		Convey("When CreateAppend", func() {
 			ap, _ := store.(types.Appender)
@@ -123,7 +121,7 @@ func TestAppender(t *testing.T, store types.Storager) {
 
 			err = ap.CommitAppend(o)
 
-			Convey("CommitAppend error should be nil", func(){
+			Convey("CommitAppend error should be nil", func() {
 				So(err, ShouldBeNil)
 			})
 

--- a/copier.go
+++ b/copier.go
@@ -17,10 +17,8 @@ import (
 
 func TestCopier(t *testing.T, store types.Storager) {
 	Convey("Given a basic Storager", t, func() {
-		Convey("The Storager should implement Copier", func() {
-			_, ok := store.(types.Copier)
-			So(ok, ShouldBeTrue)
-		})
+		_, ok := store.(types.Copier)
+		So(ok, ShouldBeTrue)
 
 		Convey("When Copy a file", func() {
 			c, _ := store.(types.Copier)

--- a/copier.go
+++ b/copier.go
@@ -17,12 +17,10 @@ import (
 
 func TestCopier(t *testing.T, store types.Storager) {
 	Convey("Given a basic Storager", t, func() {
-		_, ok := store.(types.Copier)
+		c, ok := store.(types.Copier)
 		So(ok, ShouldBeTrue)
 
 		Convey("When Copy a file", func() {
-			c, _ := store.(types.Copier)
-
 			size := rand.Int63n(4 * 1024 * 1024) // Max file size is 4MB
 			content, _ := ioutil.ReadAll(io.LimitReader(randbytes.NewRand(), size))
 			src := uuid.New().String()

--- a/direr.go
+++ b/direr.go
@@ -12,10 +12,8 @@ import (
 
 func TestDirer(t *testing.T, store types.Storager) {
 	Convey("Given a basic Storager", t, func() {
-		Convey("The Storager should implement Direr", func() {
-			_, ok := store.(types.Direr)
-			So(ok, ShouldBeTrue)
-		})
+		_, ok := store.(types.Direr)
+		So(ok, ShouldBeTrue)
 
 		Convey("When CreateDir", func() {
 			d, _ := store.(types.Direr)
@@ -63,7 +61,7 @@ func TestDirer(t *testing.T, store types.Storager) {
 			Convey("The Object Path should equal to the input path", func() {
 				So(o.Path, ShouldEqual, path)
 			})
-			
+
 			Convey("The Object Mode should be dir", func() {
 				// Dir object's mode must be Dir.
 				So(o.Mode.IsDir(), ShouldBeTrue)

--- a/direr.go
+++ b/direr.go
@@ -12,12 +12,10 @@ import (
 
 func TestDirer(t *testing.T, store types.Storager) {
 	Convey("Given a basic Storager", t, func() {
-		_, ok := store.(types.Direr)
+		d, ok := store.(types.Direr)
 		So(ok, ShouldBeTrue)
 
 		Convey("When CreateDir", func() {
-			d, _ := store.(types.Direr)
-
 			path := uuid.New().String()
 			o, err := d.CreateDir(path)
 
@@ -69,8 +67,6 @@ func TestDirer(t *testing.T, store types.Storager) {
 		})
 
 		Convey("When Stat with ModeDir", func() {
-			d, _ := store.(types.Direr)
-
 			path := uuid.New().String()
 			_, err := d.CreateDir(path)
 			if err != nil {
@@ -101,8 +97,6 @@ func TestDirer(t *testing.T, store types.Storager) {
 		})
 
 		Convey("When Delete with ModeDir", func() {
-			d, _ := store.(types.Direr)
-
 			path := uuid.New().String()
 			_, err := d.CreateDir(path)
 			if err != nil {

--- a/mover.go
+++ b/mover.go
@@ -19,12 +19,10 @@ import (
 
 func TestMover(t *testing.T, store types.Storager) {
 	Convey("Given a basic Storager", t, func() {
-		_, ok := store.(types.Mover)
+		m, ok := store.(types.Mover)
 		So(ok, ShouldBeTrue)
 
 		Convey("When Move a file", func() {
-			m, _ := store.(types.Mover)
-
 			size := rand.Int63n(4 * 1024 * 1024) // Max file size is 4MB
 			content, _ := ioutil.ReadAll(io.LimitReader(randbytes.NewRand(), size))
 			src := uuid.New().String()

--- a/mover.go
+++ b/mover.go
@@ -19,10 +19,8 @@ import (
 
 func TestMover(t *testing.T, store types.Storager) {
 	Convey("Given a basic Storager", t, func() {
-		Convey("The Storager should implement Mover", func() {
-			_, ok := store.(types.Mover)
-			So(ok, ShouldBeTrue)
-		})
+		_, ok := store.(types.Mover)
+		So(ok, ShouldBeTrue)
 
 		Convey("When Move a file", func() {
 			m, _ := store.(types.Mover)

--- a/multiparter.go
+++ b/multiparter.go
@@ -15,10 +15,8 @@ import (
 
 func TestMultiparter(t *testing.T, store types.Storager) {
 	Convey("Given a basic Storager", t, func() {
-		Convey("The Storager should implement Multiparter", func() {
-			_, ok := store.(types.Multiparter)
-			So(ok, ShouldBeTrue)
-		})
+		_, ok := store.(types.Multiparter)
+		So(ok, ShouldBeTrue)
 
 		Convey("When CreateMultipart", func() {
 			m, _ := store.(types.Multiparter)

--- a/multiparter.go
+++ b/multiparter.go
@@ -15,12 +15,10 @@ import (
 
 func TestMultiparter(t *testing.T, store types.Storager) {
 	Convey("Given a basic Storager", t, func() {
-		_, ok := store.(types.Multiparter)
+		m, ok := store.(types.Multiparter)
 		So(ok, ShouldBeTrue)
 
 		Convey("When CreateMultipart", func() {
-			m, _ := store.(types.Multiparter)
-
 			path := uuid.New().String()
 			o, err := m.CreateMultipart(path)
 
@@ -50,8 +48,6 @@ func TestMultiparter(t *testing.T, store types.Storager) {
 		})
 
 		Convey("When Delete with multipart id", func() {
-			m, _ := store.(types.Multiparter)
-
 			path := uuid.New().String()
 			o, err := m.CreateMultipart(path)
 			if err != nil {
@@ -70,8 +66,6 @@ func TestMultiparter(t *testing.T, store types.Storager) {
 		})
 
 		Convey("When Stat with multipart id", func() {
-			m, _ := store.(types.Multiparter)
-
 			path := uuid.New().String()
 			o, err := m.CreateMultipart(path)
 			if err != nil {
@@ -110,8 +104,6 @@ func TestMultiparter(t *testing.T, store types.Storager) {
 		})
 
 		Convey("When Create with multipart id", func() {
-			m, _ := store.(types.Multiparter)
-
 			path := uuid.New().String()
 			o, err := m.CreateMultipart(path)
 			if err != nil {
@@ -145,8 +137,6 @@ func TestMultiparter(t *testing.T, store types.Storager) {
 		})
 
 		Convey("When WriteMultipart", func() {
-			m, _ := store.(types.Multiparter)
-
 			path := uuid.New().String()
 			o, err := m.CreateMultipart(path)
 			if err != nil {
@@ -179,8 +169,6 @@ func TestMultiparter(t *testing.T, store types.Storager) {
 		})
 
 		Convey("When ListMultiPart", func() {
-			m, _ := store.(types.Multiparter)
-
 			path := uuid.New().String()
 			o, err := m.CreateMultipart(path)
 			if err != nil {
@@ -222,8 +210,6 @@ func TestMultiparter(t *testing.T, store types.Storager) {
 		})
 
 		Convey("When CompletePart", func() {
-			m, _ := store.(types.Multiparter)
-
 			path := uuid.New().String()
 			o, err := m.CreateMultipart(path)
 			if err != nil {

--- a/storager.go
+++ b/storager.go
@@ -20,13 +20,7 @@ import (
 
 func TestStorager(t *testing.T, store types.Storager) {
 	Convey("Given a basic Storager", t, func() {
-		var err error
-
 		So(store, ShouldNotBeNil)
-
-		Convey("The error should be nil", func() {
-			So(err, ShouldBeNil)
-		})
 
 		Convey("When String called", func() {
 			s := store.String()

--- a/storager.go
+++ b/storager.go
@@ -22,9 +22,7 @@ func TestStorager(t *testing.T, store types.Storager) {
 	Convey("Given a basic Storager", t, func() {
 		var err error
 
-		Convey("The Storager should not be nil", func() {
-			So(store, ShouldNotBeNil)
-		})
+		So(store, ShouldNotBeNil)
 
 		Convey("The error should be nil", func() {
 			So(err, ShouldBeNil)
@@ -235,7 +233,7 @@ func TestStorager(t *testing.T, store types.Storager) {
 				}
 			}()
 
-			it, err := store.List("",  ps.WithListMode(types.ListModeDir))
+			it, err := store.List("", ps.WithListMode(types.ListModeDir))
 			Convey("The error should be nil", func() {
 				So(err, ShouldBeNil)
 			})


### PR DESCRIPTION
- Remove redundant type assertion
- Remove the first sub-`Convey`. Then when the first `So` fails, the top-level `Convey` will halt.